### PR TITLE
Add option to check out the main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ Script for cleanup of local git working directories.
 
 The `git_cleanup.sh` script is designed to help you clean up your local Git repositories. It performs the following tasks:
 
-- Optionally check out the main branch.
+- Optionally check out the main branch. [-m]
 - Fetches updates from remote repositories and prunes any remote-tracking references that no longer exist on the remote.
 - Removes local branches that have been deleted on the remote.
 - Removes local branches that have been merged into the main branch.
 - Prunes orphaned objects from the local repository.
 - Checks for old stashes and notifies if any are found.
-- Optionally removes any untracked branches.
+- Optionally removes any untracked branches. [-u]
 
 ## Usage
 
 You can run the script with the following options:
 
 ```sh
-Usage: ./git_cleanup.sh [-d directory] [-u]
+Usage: ./git_cleanup.sh [-d directory] [-u] [-m]
 ```
 
 * -d directory: Specify the directory to clean up. Defaults to the current directory (.).

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -16,10 +16,11 @@ error_echo() {
 }
 
 # Parse command-line arguments
-while getopts "d:u" opt; do
+while getopts "d:u:m" opt; do
   case $opt in
     d) DIRECTORY="$OPTARG" ;;
     u) DELETE_UNTRACKED=true ;;
+    m) CHECKOUT_MAIN=true ;;
     *)
       echo "Usage: $0 [-d directory] [-u]"
       exit 1
@@ -72,8 +73,18 @@ checkout_main_branch() {
     if [ "$CHECKOUT_MAIN" = true ]; then
         local main_branch
         main_branch=$(detect_main_branch)
-        echo "Checking out main branch: $main_branch"
-        git checkout "$main_branch" 2>/dev/null || error_echo "Failed to checkout main branch: $main_branch"
+
+        local current_branch
+        current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+        if [ "$current_branch" = "$main_branch" ]; then
+            info_echo "Already on main branch: $main_branch"
+            return
+        fi
+
+        info_echo "Checking out main branch: $main_branch"
+        if ! git checkout "$main_branch"; then
+            error_echo "Failed to checkout main branch: $main_branch"
+        fi
     fi
 }   
 


### PR DESCRIPTION
## Proposed changes

When doing cleanup there are times where the repo is already on a branch that has been pushed. Add an argument that allows checking out the main branch before doing cleanup.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Link to issue to close it

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
