### PR TITLE
Add git worktree cleanup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The `git_cleanup.sh` script is designed to help you clean up your local Git repo
 - Fetches updates from remote repositories and prunes any remote-tracking references that no longer exist on the remote.
 - Removes local branches that have been deleted on the remote.
 - Removes local branches that have been merged into the main branch.
+- Skips branches that are currently checked out in any linked Git worktree.
+- Prunes stale Git worktree metadata.
 - Prunes orphaned objects from the local repository.
 - Checks for old stashes and notifies if any are found.
 - Optionally removes any untracked branches. [-u]
@@ -24,11 +26,14 @@ Usage: ./git_cleanup.sh [-d directory] [-u] [-m]
 
 * -d directory: Specify the directory to clean up. Defaults to the current directory (.).
 * -u: Removes untracked branches.
+* -m: Checks out the main branch before cleanup when possible.
 
 ### Behavior
 
-If the specified directory contains a .git file, the script will clean up that repository.
-If the specified directory does not contain a .git file, the script will recurse into child directories to find and clean up Git repositories.
+If the specified directory is inside a Git working tree, including a linked worktree, the script will clean up that repository.
+If the specified directory is not inside a Git working tree, the script will recurse into child directories to find `.git` directories and `.git` files, so both regular repositories and linked worktrees are included.
+
+When deleting branches, the script skips branches that are checked out by any worktree because Git does not allow those branches to be deleted. When `-m` is used from a worktree, the script also skips checking out the main branch if that branch is already checked out by another worktree.
 
 ### Examples
 

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -15,6 +15,10 @@ error_echo() {
     printf "%b%s%b\n" "$RED" "$1" "$NO_COLOR" >&2
 }
 
+usage() {
+    echo "Usage: $0 [-d directory] [-u] [-m]"
+}
+
 # Parse command-line arguments
 while getopts "d:u:m" opt; do
   case $opt in
@@ -22,7 +26,7 @@ while getopts "d:u:m" opt; do
     u) DELETE_UNTRACKED=true ;;
     m) CHECKOUT_MAIN=true ;;
     *)
-      echo "Usage: $0 [-d directory] [-u]"
+      usage
       exit 1
       ;;
   esac
@@ -30,29 +34,41 @@ done
 
 # Default values
 DIRECTORY=${DIRECTORY:-.}
-DELETE_UNTRACKED=${DELETE_UNTRACKED:false}
-CHECKOUT_MAIN=${CHECKOUT_MAIN:false}
+DELETE_UNTRACKED=${DELETE_UNTRACKED:-false}
+CHECKOUT_MAIN=${CHECKOUT_MAIN:-false}
 
 # Determine the main branch dynamically
 detect_main_branch() {
-    git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main"
+    local main_branch
+    main_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)
+    main_branch=${main_branch#origin/}
+
+    if [ -n "$main_branch" ]; then
+        echo "$main_branch"
+    elif git show-ref --verify --quiet refs/heads/main; then
+        echo "main"
+    elif git show-ref --verify --quiet refs/heads/master; then
+        echo "master"
+    else
+        echo "main"
+    fi
 }
 
 # Function to iterate through directories and clean repositories
 iterate_directories() {
     info_echo "Checking projects in $DIRECTORY..."
-    cd "$DIRECTORY" || exit 1
 
-    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        info_echo "Processing $DIRECTORY."
+    if git -C "$DIRECTORY" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        cd "$DIRECTORY" || exit 1
+        info_echo "Processing $(git rev-parse --show-toplevel)."
         clean_repository
     else
-        find "$DIRECTORY" -type d -name ".git" | while read -r gitdir; do
+        find "$DIRECTORY" \( -type d -o -type f \) -name ".git" -print | while read -r gitdir; do
             repo=$(dirname "$gitdir")
             cd "$repo" || continue
             info_echo "Processing $repo."
             clean_repository
-            cd - || exit
+            cd - >/dev/null || exit
         done
     fi
 }
@@ -61,6 +77,7 @@ iterate_directories() {
 clean_repository() {
     checkout_main_branch
     fetch_remotes
+    prune_worktrees
     remove_deleted_branches
     remove_merged_branches
     remove_untracked
@@ -81,6 +98,11 @@ checkout_main_branch() {
             return
         fi
 
+        if is_branch_checked_out_elsewhere "$main_branch"; then
+            error_echo "Cannot checkout $main_branch because it is checked out in another worktree."
+            return
+        fi
+
         if ! git checkout "$main_branch"; then
             error_echo "Failed to checkout the main branch."
         fi
@@ -97,11 +119,45 @@ fetch_remotes() {
     git fetch --prune $(git_remotes)
 }
 
+# Prune stale worktree metadata
+prune_worktrees() {
+    if git worktree list >/dev/null 2>&1; then
+        echo "Pruning stale worktree metadata..."
+        git worktree prune
+    fi
+}
+
+checked_out_worktree_branches() {
+    git worktree list --porcelain 2>/dev/null | sed -n 's/^branch refs\/heads\///p'
+}
+
+is_branch_checked_out() {
+    local branch="$1"
+    checked_out_worktree_branches | grep -Fxq "$branch"
+}
+
+is_branch_checked_out_elsewhere() {
+    local branch="$1"
+    local current_branch
+    current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
+
+    if [ "$branch" = "$current_branch" ]; then
+        return 1
+    fi
+
+    is_branch_checked_out "$branch"
+}
+
 # Function to delete branches
 delete_branches() {
     local branches="$1"
     if [[ -n "$branches" ]]; then
         echo "$branches" | while read -r branch; do
+            if is_branch_checked_out "$branch"; then
+                error_echo "Skipping $branch because it is checked out in a worktree."
+                continue
+            fi
+
             git branch -D "$branch"
         done
     fi
@@ -121,9 +177,9 @@ remove_merged_branches() {
     local main_branch
     main_branch=$(detect_main_branch)
     local current_branch
-    current_branch=$(git symbolic-ref --short HEAD)
+    current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
     local branches
-    branches=$(git branch --merged "$main_branch" | sed 's/^ *//g' | grep -v -e "$main_branch" -e "$current_branch")
+    branches=$(git branch --format "%(refname:short)" --merged "$main_branch" | grep -Fvx -e "$main_branch" -e "$current_branch")
     delete_branches "$branches"
 }
 
@@ -138,7 +194,7 @@ remove_untracked() {
     if [ "$DELETE_UNTRACKED" = true ]; then
         echo "Removing untracked branches..."
         local branches
-        branches=$(git branch --no-merged)
+        branches=$(git branch --format "%(refname:short)" --no-merged)
         delete_branches "$branches"
     fi
 }


### PR DESCRIPTION
## Proposed changes

Adds Git worktree support to the cleanup script. The script now discovers linked worktrees by finding `.git` files as well as `.git` directories, prunes stale worktree metadata, skips deleting branches that are checked out in any worktree, and avoids checking out the main branch when it is already checked out elsewhere.

The README has been updated to document the new worktree behavior and the existing `-m` option.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Link to issue to close it

## Further comments

Validation performed:

- `bash -n git_cleanup.sh`
- Local integration test with a regular repository plus linked worktree confirmed checked-out worktree branches are skipped.
- Local integration test with `-m` confirmed checkout is skipped when `main` is already checked out in another worktree.

No linked issue was found in the branch name or commit metadata.