### PR TITLE
Add release tagging workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,79 @@
+name: Tag Release on PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  tag_release:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version bump
+        id: bump
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
+        run: |
+          labels=$(echo "$LABELS_JSON" | jq -r '.[].name')
+
+          if echo "$labels" | grep -Fxq "semver:major"; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$labels" | grep -Fxq "semver:minor"; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Calculate next version
+        id: version
+        env:
+          BUMP_TYPE: ${{ steps.bump.outputs.type }}
+        run: |
+          latest_tag=$(git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
+          latest_version=${latest_tag#v}
+
+          if [ -z "$latest_version" ]; then
+            latest_version="0.0.0"
+          fi
+
+          IFS='.' read -r major minor patch <<< "$latest_version"
+
+          case "$BUMP_TYPE" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch)
+              patch=$((patch + 1))
+              ;;
+          esac
+
+          new_version="v$major.$minor.$patch"
+          echo "version=$new_version" >> "$GITHUB_OUTPUT"
+          echo "Next release: $new_version"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          gh release create "$VERSION" \
+            --target "$TARGET_SHA" \
+            --title "Release $VERSION" \
+            --generate-notes

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,16 +1,21 @@
-name: Tag Release on PR Merge
+name: Determine Release Version
 
 on:
   pull_request:
     types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - labeled
+      - unlabeled
       - closed
 
 permissions:
   contents: write
 
 jobs:
-  tag_release:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch
+  determine_version:
     runs-on: ubuntu-latest
 
     steps:
@@ -67,7 +72,20 @@ jobs:
           echo "version=$new_version" >> "$GITHUB_OUTPUT"
           echo "Next release: $new_version"
 
+      - name: Summarize release version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BUMP_TYPE: ${{ steps.bump.outputs.type }}
+        run: |
+          {
+            echo "## Release version"
+            echo
+            echo "Version bump: \`$BUMP_TYPE\`"
+            echo "Next version: \`$VERSION\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Create GitHub release
+        if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ cleanup
 
 This will execute the [git_cleanup.sh](./git_cleanup.sh) script on the directory specified by the `$PROJECTS` environment variable.
 
+## Releases
+
+When a pull request is merged, the release workflow creates the next GitHub release tag. Add one of these labels to the pull request to control the version bump:
+
+* `semver:major`: Bumps `v1.2.3` to `v2.0.0`.
+* `semver:minor`: Bumps `v1.2.3` to `v1.3.0`.
+* `semver:patch`: Bumps `v1.2.3` to `v1.2.4`.
+
+If no semver label is present, the workflow defaults to a patch release.
+
 ## Disclaimer
 
 This script has been cleaned up and improved using Large Language Models (LLMs) to ensure better readability, maintainability, and functionality. Please review the code and test it in your environment before using it in production.

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ cleanup
 
 This will execute the [git_cleanup.sh](./git_cleanup.sh) script on the directory specified by the `$PROJECTS` environment variable.
 
-## Releases
+## Release Versioning
 
-When a pull request is merged, the release workflow creates the next GitHub release tag. Add one of these labels to the pull request to control the version bump:
+When a pull request is opened or updated, the release version workflow determines the next GitHub release tag. When the pull request merges into the default branch, the workflow creates that GitHub release. Add one of these labels to the pull request to control the version bump:
 
 * `semver:major`: Bumps `v1.2.3` to `v2.0.0`.
 * `semver:minor`: Bumps `v1.2.3` to `v1.3.0`.


### PR DESCRIPTION
## Proposed changes

Adds a GitHub Actions workflow that creates a GitHub release when a pull request is merged into the default branch.

The workflow chooses the next semantic version from PR labels:

- `semver:major` bumps the major version and resets minor and patch.
- `semver:minor` bumps the minor version and resets patch.
- `semver:patch` bumps the patch version.
- If no semver label is present, the workflow defaults to a patch release.

The README now documents the release labels and default patch behavior.

Fixes #9

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Link to issue to close it

## Further comments

Validation performed:

- Parsed `.github/workflows/tag-release.yml` with Ruby YAML loading.
- Tested the major, minor, and patch Bash version bump paths locally.