### PR TITLE
Remove worktrees for deleted branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The `git_cleanup.sh` script is designed to help you clean up your local Git repo
 - Optionally check out the main branch. [-m]
 - Fetches updates from remote repositories and prunes any remote-tracking references that no longer exist on the remote.
 - Removes local branches that have been deleted on the remote.
+- Removes linked worktrees whose checked-out branch has been deleted on the remote.
 - Removes local branches that have been merged into the main branch.
 - Skips branches that are currently checked out in any linked Git worktree.
 - Prunes stale Git worktree metadata.
@@ -33,7 +34,9 @@ Usage: ./git_cleanup.sh [-d directory] [-u] [-m]
 If the specified directory is inside a Git working tree, including a linked worktree, the script will clean up that repository.
 If the specified directory is not inside a Git working tree, the script will recurse into child directories to find `.git` directories and `.git` files, so both regular repositories and linked worktrees are included.
 
-When deleting branches, the script skips branches that are checked out by any worktree because Git does not allow those branches to be deleted. When `-m` is used from a worktree, the script also skips checking out the main branch if that branch is already checked out by another worktree.
+When a linked worktree has a checked-out branch whose remote tracking branch has been deleted, the script removes that worktree and deletes the local branch. If the deleted branch is checked out in the current worktree, the script skips it because removing the directory it is running from is unsafe.
+
+When deleting other branches, the script skips branches that are checked out by any worktree because Git does not allow those branches to be deleted. When `-m` is used from a worktree, the script also skips checking out the main branch if that branch is already checked out by another worktree.
 
 ### Examples
 

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -78,6 +78,7 @@ clean_repository() {
     checkout_main_branch
     fetch_remotes
     prune_worktrees
+    remove_deleted_worktrees
     remove_deleted_branches
     remove_merged_branches
     remove_untracked
@@ -148,6 +149,51 @@ is_branch_checked_out_elsewhere() {
     is_branch_checked_out "$branch"
 }
 
+gone_tracking_branches() {
+    git branch --format "%(refname:short) %(upstream:track)" | awk '$2 == "[gone]" {print $1}'
+}
+
+worktree_branches() {
+    git worktree list --porcelain 2>/dev/null | awk '
+        /^worktree / { path = substr($0, 10) }
+        /^branch refs\/heads\// {
+            branch = substr($0, 19)
+            print path "\t" branch
+        }
+    '
+}
+
+remove_deleted_worktrees() {
+    echo "Removing worktrees with deleted remote tracking..."
+    local branches
+    branches=$(gone_tracking_branches)
+
+    if [[ -z "$branches" ]]; then
+        return
+    fi
+
+    local current_worktree
+    current_worktree=$(git rev-parse --show-toplevel)
+
+    worktree_branches | while IFS=$'\t' read -r worktree branch; do
+        if ! echo "$branches" | grep -Fxq "$branch"; then
+            continue
+        fi
+
+        if [ "$worktree" = "$current_worktree" ]; then
+            error_echo "Skipping $branch because it is checked out in the current worktree."
+            continue
+        fi
+
+        echo "Removing worktree $worktree for deleted branch $branch..."
+        if git worktree remove "$worktree"; then
+            git branch -D "$branch"
+        else
+            error_echo "Failed to remove worktree $worktree for branch $branch."
+        fi
+    done
+}
+
 # Function to delete branches
 delete_branches() {
     local branches="$1"
@@ -167,7 +213,7 @@ delete_branches() {
 remove_deleted_branches() {
     echo "Removing local branches with deleted remote tracking..."
     local branches
-    branches=$(git branch --format "%(refname:short) %(upstream:track)" | awk '$2 == "[gone]" {print $1}')
+    branches=$(gone_tracking_branches)
     delete_branches "$branches"
 }
 


### PR DESCRIPTION
## Proposed changes

Removes linked worktrees when their checked-out branch has a deleted remote tracking branch. After `git fetch --prune` marks a local branch as `[gone]`, the cleanup script now removes any linked worktree for that branch and then deletes the local branch.

The script skips this removal when the deleted branch is checked out in the current worktree, so it does not remove the directory it is running from. The README now documents this behavior.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Link to issue to close it

## Further comments

Validation performed:

- `bash -n git_cleanup.sh`
- Local integration test confirmed a linked worktree for a deleted remote branch is removed and its local branch is deleted.
- Local integration test confirmed the current-worktree case is skipped safely.