### PR TITLE
chore: seed CHANGELOG.md with pre-release-please history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## [2.0.1](https://github.com/richwklein/git-cleanup/compare/v2.0.0...v2.0.1) (2026-05-08)
+
+### Miscellaneous Changes
+
+- bump actions/checkout from 4 to 6 in the github-actions group ([#18](https://github.com/richwklein/git-cleanup/pull/18)) ([5274eef](https://github.com/richwklein/git-cleanup/commit/5274eef))
+
+## [2.0.0](https://github.com/richwklein/git-cleanup/compare/v1.1.0...v2.0.0) (2026-05-04)
+
+### ⚠ BREAKING CHANGES
+
+- Stale worktrees for deleted branches are now removed automatically during cleanup.
+
+### Features
+
+- remove worktrees for deleted branches ([#17](https://github.com/richwklein/git-cleanup/pull/17)) ([53e3a27](https://github.com/richwklein/git-cleanup/commit/53e3a27))
+
+## [1.1.0](https://github.com/richwklein/git-cleanup/compare/v1.0.0...v1.1.0) (2026-05-04)
+
+### Features
+
+- add git worktree cleanup support ([#15](https://github.com/richwklein/git-cleanup/pull/15)) ([f7b4dda](https://github.com/richwklein/git-cleanup/commit/f7b4dda))
+
+## [1.0.0](https://github.com/richwklein/git-cleanup/commits/v1.0.0) (2026-05-04)
+
+### Features
+
+- add the cleanup script ([#1](https://github.com/richwklein/git-cleanup/pull/1)) ([9328f98](https://github.com/richwklein/git-cleanup/commit/9328f98))
+- add option to check out the main branch ([#11](https://github.com/richwklein/git-cleanup/pull/11)) ([a32801b](https://github.com/richwklein/git-cleanup/commit/a32801b))
+
+### Bug Fixes
+
+- correct branch argument passing ([#10](https://github.com/richwklein/git-cleanup/pull/10)) ([1f3d825](https://github.com/richwklein/git-cleanup/commit/1f3d825))
+
+### Miscellaneous Changes
+
+- update repo config ([#2](https://github.com/richwklein/git-cleanup/pull/2)) ([1964973](https://github.com/richwklein/git-cleanup/commit/1964973))
+- switch shell ([#3](https://github.com/richwklein/git-cleanup/pull/3)) ([e54f777](https://github.com/richwklein/git-cleanup/commit/e54f777))
+- updated script ([#8](https://github.com/richwklein/git-cleanup/pull/8)) ([8ac98a1](https://github.com/richwklein/git-cleanup/commit/8ac98a1))
+- improve logging around checking out the main branch ([#13](https://github.com/richwklein/git-cleanup/pull/13)) ([5116291](https://github.com/richwklein/git-cleanup/commit/5116291))
+- change interval for dependabot PRs ([#14](https://github.com/richwklein/git-cleanup/pull/14)) ([88386fd](https://github.com/richwklein/git-cleanup/commit/88386fd))
+- add release tagging workflow ([#16](https://github.com/richwklein/git-cleanup/pull/16)) ([2dd7ba0](https://github.com/richwklein/git-cleanup/commit/2dd7ba0))


### PR DESCRIPTION
## Summary

Backfills `CHANGELOG.md` with the four releases that existed before release-please took over. Mirrors the pattern from [richwklein/agingdeveloper#917](https://github.com/richwklein/agingdeveloper/pull/917).

## Linked issue

Closes #

## Type of change

- [x] Documentation / content

## Details

Seeded entries:

- **v2.0.1** (2026-05-08) — dependabot action bump
- **v2.0.0** (2026-05-04) — worktree removal (flagged as BREAKING: stale worktrees for deleted branches now auto-removed)
- **v1.1.0** (2026-05-04) — git worktree cleanup support
- **v1.0.0** (2026-05-04) — initial release (9 PRs aggregated)

PRs categorized by intent (features / fixes / misc) since the original titles weren't Conventional Commits. The v1.0.0 commit URLs use the `commits/v1.0.0` form because there's no prior tag to compare against.

release-please will prepend new entries to the top of this file going forward. Existing GitHub Releases remain as-is and aren't replaced.

## Why this matters

Without the seed, the first release-please run after v2.0.1 would create a `CHANGELOG.md` that *only* contained the new release — readers landing on it would lose visibility into prior history. The seed preserves the historical record in one place.

## Release / deploy impact

- [x] Safe to label `no-deploy`

## Validation

- [x] Manually verified changes
- [x] Documentation updated where appropriate

Markdown lint check shouldn't run on this file (no markdownlint workflow in this repo).