### PR TITLE
chore: add .gitignore and upgrade actions to Node 24

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -11,13 +11,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# build output
+dist/
+build/
+out/
+.cache/
+
+# dependencies
+node_modules/
+
+# logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# coverage
+coverage/
+
+# env files
+.env
+.env.*
+!.env.example
+
+# local-only tool configs (Claude Code, editor overlays, etc.)
+settings.local.*
+
+# worktrees
+.worktrees/
+
+# editor / OS
+.DS_Store
+Icon?
+Thumbs.db
+.idea/
+*.swp


### PR DESCRIPTION
## Summary

- Adds `.gitignore` (was missing from the repo — flagged by `repo-template-audit`)
- Upgrades `googleapis/release-please-action` v4 → v5 and `actions/create-github-app-token` v1 → v3 (Node 24 required on GitHub Actions runners starting June 2, 2026)

No input changes — both action upgrades are drop-in replacements for the inputs currently used.

## Test plan

- [ ] Lint check passes
- [ ] Release workflow runs correctly after merge (no Node 20 deprecation warnings)
- [ ] Audit shows .gitignore no longer missing