### PR TITLE
chore(audit): sync missing files from repo-template-base

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "davidanson.vscode-markdownlint",
+    "github.vscode-github-actions",
+    "streetsidesoftware.code-spell-checker"
+  ],
+  "unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "files.exclude": {
+    ".git/": true
+  },
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "editor.tabCompletion": "on",
+  "editor.rulers": [80, 100, 120],
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "editor.wordWrap": "wordWrapColumn",
+  "cSpell.words": ["codeql", "richwklein"],
+  "[markdown]": {
+    "editor.wordWrap": "wordWrapColumn"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Syncs three files that were missing from this repo relative to the `richwklein/repo-template-base` template. Identified via a `/repo-template-audit` run. The CodeQL workflow was intentionally excluded — CodeQL has no language support for shell scripts.

## Linked issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

Added files:
- `CLAUDE.md` — Claude Code instructions (delegates to `@AGENTS.md`)
- `.vscode/extensions.json` — recommended VS Code extensions (EditorConfig, markdownlint, GitHub Actions, Code Spell Checker)
- `.vscode/settings.json` — workspace editor defaults (format on save, rulers, tab size, etc.)

No logic changes. All three files were fetched verbatim from the template.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

`CONTRIBUTING.md` has one line of intentional drift (a link to `docs/BRANCH_PROTECTION.md`) and was left as-is.