### PR TITLE
fix(release): explicitly disable component in tag name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.1.0](https://github.com/richwklein/git-cleanup/compare/git-cleanup-v2.0.1...git-cleanup-v2.1.0) (2026-05-22)
+## [2.1.0](https://github.com/richwklein/git-cleanup/compare/v2.0.1...v2.1.0) (2026-05-22)
 
 
 ### Features

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "git-cleanup",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "draft": false,
       "prerelease": false,


### PR DESCRIPTION
## Summary

- Adds `include-component-in-tag: false` to `release-please-config.json`
- Updates the `CHANGELOG.md` compare link to match the renamed `v2.1.0` tag

## Why

Without `include-component-in-tag: false` explicitly set, release-please derives the tag name from `package-name` and produces `git-cleanup-v{version}` instead of `v{version}`. The existing `git-cleanup-v2.1.0` release and tag have been deleted and recreated as `v2.1.0`. The earlier `v1.0.0`–`v2.0.1` tags were already in the correct format and are unchanged.