### PR TITLE
feat: add bare git repository support

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install bats
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y bats
+
+      - name: Configure git for tests
+        run: |
+          git config --global user.email "ci@test.com"
+          git config --global user.name "CI"
+          git config --global commit.gpgsign false
+          git config --global init.defaultBranch main
+
+      - name: Run tests
+        run: bats test/

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ Script for cleanup of local git working directories.
 
 ## Description
 
-The `git_cleanup.sh` script is designed to help you clean up your local Git repositories. It performs the following tasks:
+The `git_cleanup.sh` script is designed to help you clean up your local Git repositories. It supports both regular repositories and bare repositories (used with the git worktree workflow). It performs the following tasks:
 
-- Optionally check out the main branch. [-m]
 - Fetches updates from remote repositories and prunes any remote-tracking references that no longer exist on the remote.
-- Removes local branches that have been deleted on the remote.
+- Fast-forwards the main branch to the latest remote commit without requiring a checkout. *(bare repos)*
+- Optionally checks out the main branch before cleanup. [-m] *(regular repos only)*
 - Removes linked worktrees whose checked-out branch has been deleted on the remote.
+- Removes local branches that have been deleted on the remote.
 - Removes local branches that have been merged into the main branch.
 - Skips branches that are currently checked out in any linked Git worktree.
 - Prunes stale Git worktree metadata.
 - Prunes orphaned objects from the local repository.
 - Checks for old stashes and notifies if any are found.
-- Optionally removes any untracked branches. [-u]
+- Optionally removes any untracked branches. [-u] *(regular repos only)*
 
 ## Usage
 
@@ -25,14 +26,21 @@ You can run the script with the following options:
 Usage: ./git_cleanup.sh [-d directory] [-u] [-m]
 ```
 
-* -d directory: Specify the directory to clean up. Defaults to the current directory (.).
-* -u: Removes untracked branches.
-* -m: Checks out the main branch before cleanup when possible.
+- -d directory: Specify the directory to clean up. Defaults to the current directory (.).
+- -u: Removes untracked branches.
+- -m: Checks out the main branch before cleanup when possible.
 
 ### Behavior
 
-If the specified directory is inside a Git working tree, including a linked worktree, the script will clean up that repository.
-If the specified directory is not inside a Git working tree, the script will recurse into child directories to find `.git` directories and `.git` files, so both regular repositories and linked worktrees are included.
+**Directory detection**
+
+If the specified directory is a bare repository, the script cleans it directly. If the directory is inside a regular Git working tree (including a linked worktree), the script cleans that repository. Otherwise the script scans direct subdirectories: subdirectories containing a `.git` directory are treated as regular repositories; subdirectories that are bare repositories are cleaned as bare repos. Each repository is processed once regardless of how many linked worktrees it has.
+
+**Bare repositories**
+
+Bare repos have no working tree, so `checkout_main_branch` and `remove_untracked` are skipped. Instead, the script fast-forwards the main branch directly using `git fetch origin main:main --ff-only`, keeping it current without requiring a checkout. The `-m` flag is accepted but has no effect on bare repos.
+
+**Worktree-aware branch deletion**
 
 When a linked worktree has a checked-out branch whose remote tracking branch has been deleted, the script removes that worktree and deletes the local branch. If the deleted branch is checked out in the current worktree, the script skips it because removing the directory it is running from is unsafe.
 
@@ -56,6 +64,18 @@ Cleaning untracked branches
 
 ```sh
 ./git_cleanup.sh -d /path/to/dir -u
+```
+
+Cleaning a bare repository
+
+```sh
+./git_cleanup.sh -d /path/to/bare-repo
+```
+
+Cleaning a projects directory containing a mix of regular and bare repositories
+
+```sh
+./git_cleanup.sh -d /path/to/projects
 ```
 
 ## Creating a Command Line Alias
@@ -94,9 +114,9 @@ This will execute the [git_cleanup.sh](./git_cleanup.sh) script on the directory
 
 When a pull request is opened or updated, the release version workflow determines the next GitHub release tag. When the pull request merges into the default branch, the workflow creates that GitHub release. Add one of these labels to the pull request to control the version bump:
 
-* `semver:major`: Bumps `v1.2.3` to `v2.0.0`.
-* `semver:minor`: Bumps `v1.2.3` to `v1.3.0`.
-* `semver:patch`: Bumps `v1.2.3` to `v1.2.4`.
+- `semver:major`: Bumps `v1.2.3` to `v2.0.0`.
+- `semver:minor`: Bumps `v1.2.3` to `v1.3.0`.
+- `semver:patch`: Bumps `v1.2.3` to `v1.2.4`.
 
 If no semver label is present, the workflow defaults to a patch release.
 

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -58,22 +58,47 @@ detect_main_branch() {
 iterate_directories() {
     info_echo "Checking projects in $DIRECTORY..."
 
+    local is_bare
+    is_bare=$(git -C "$DIRECTORY" rev-parse --is-bare-repository 2>/dev/null)
+
+    if [ "$is_bare" = "true" ]; then
+        cd "$DIRECTORY" || exit 1
+        info_echo "Processing bare repo $(pwd)."
+        clean_bare_repository
+        return
+    fi
+
     if git -C "$DIRECTORY" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         cd "$DIRECTORY" || exit 1
         info_echo "Processing $(git rev-parse --show-toplevel)."
         clean_repository
-    else
-        find "$DIRECTORY" \( -type d -o -type f \) -name ".git" -print | while read -r gitdir; do
-            repo=$(dirname "$gitdir")
-            cd "$repo" || continue
-            info_echo "Processing $repo."
-            clean_repository
-            cd - >/dev/null || exit
-        done
+        return
     fi
+
+    # Process regular repos via their .git directory
+    find "$DIRECTORY" -type d -name ".git" | while read -r gitdir; do
+        local repo
+        repo=$(dirname "$gitdir")
+        cd "$repo" || continue
+        info_echo "Processing $repo."
+        clean_repository
+        cd - >/dev/null || exit
+    done
+
+    # Process bare repos — check each direct subdirectory
+    find "$DIRECTORY" -mindepth 1 -maxdepth 1 -type d | while read -r subdir; do
+        local subdir_is_bare
+        subdir_is_bare=$(git -C "$subdir" rev-parse --is-bare-repository 2>/dev/null)
+        if [ "$subdir_is_bare" = "true" ]; then
+            cd "$subdir" || continue
+            info_echo "Processing bare repo $subdir."
+            clean_bare_repository
+            cd - >/dev/null || exit
+        fi
+    done
 }
 
-# Function to clean a repository
+# Function to clean a regular repository
 clean_repository() {
     checkout_main_branch
     fetch_remotes
@@ -82,6 +107,18 @@ clean_repository() {
     remove_deleted_branches
     remove_merged_branches
     remove_untracked
+    prune_local_objects
+    check_stashes
+}
+
+# Function to clean a bare repository
+clean_bare_repository() {
+    fetch_remotes
+    fast_forward_main
+    prune_worktrees
+    remove_deleted_worktrees
+    remove_deleted_branches
+    remove_merged_branches
     prune_local_objects
     check_stashes
 }
@@ -119,6 +156,15 @@ fetch_remotes() {
     echo "Fetching remote changes and pruning removed branches..."
     # shellcheck disable=SC2046 # intentional word-splitting on remote names
     git fetch --prune $(git_remotes)
+}
+
+# Fast-forward main branch without checking it out (safe in bare repos and worktrees)
+fast_forward_main() {
+    local main_branch
+    main_branch=$(detect_main_branch)
+    echo "Fast-forwarding $main_branch..."
+    git fetch origin "$main_branch:$main_branch" --ff-only 2>/dev/null \
+        || error_echo "Could not fast-forward $main_branch (diverged or up to date)."
 }
 
 # Prune stale worktree metadata
@@ -174,7 +220,7 @@ remove_deleted_worktrees() {
     fi
 
     local current_worktree
-    current_worktree=$(git rev-parse --show-toplevel)
+    current_worktree=$(git rev-parse --show-toplevel 2>/dev/null || git rev-parse --absolute-git-dir 2>/dev/null)
 
     worktree_branches | while IFS=$'\t' read -r worktree branch; do
         if ! echo "$branches" | grep -Fxq "$branch"; then

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -163,8 +163,21 @@ fast_forward_main() {
     local main_branch
     main_branch=$(detect_main_branch)
     echo "Fast-forwarding $main_branch..."
-    git fetch origin "$main_branch:$main_branch" --ff-only 2>/dev/null \
-        || error_echo "Could not fast-forward $main_branch (diverged or up to date)."
+
+    # If main is checked out in a worktree, pull from there — git refuses
+    # to update a branch via fetch refspec while it is checked out elsewhere.
+    local main_worktree
+    main_worktree=$(git worktree list --porcelain | awk \
+        -v ref="refs/heads/$main_branch" \
+        '/^worktree / { path = substr($0, 10) } $0 == "branch " ref { print path; exit }')
+
+    if [ -n "$main_worktree" ]; then
+        git -C "$main_worktree" pull --ff-only origin "$main_branch" 2>/dev/null \
+            || error_echo "Could not fast-forward $main_branch (diverged or up to date)."
+    else
+        git fetch origin "$main_branch:$main_branch" --ff-only 2>/dev/null \
+            || error_echo "Could not fast-forward $main_branch (diverged or up to date)."
+    fi
 }
 
 # Prune stale worktree metadata

--- a/test/bare_repo.bats
+++ b/test/bare_repo.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# Tests for bare repository cleanup
+
+setup() {
+    load helpers
+    setup_bare_repo
+}
+
+@test "fast-forwards main when remote is ahead" {
+    # Push a new commit to remote from a separate clone
+    local pusher="$BATS_TEST_TMPDIR/pusher"
+    git clone "$REMOTE_DIR" "$pusher"
+    git -C "$pusher" config user.email "test@test.com"
+    git -C "$pusher" config user.name "Test"
+    git -C "$pusher" config commit.gpgsign false
+    git -C "$pusher" commit --allow-empty -m "remote advance"
+    git -C "$pusher" push origin main
+    local remote_sha
+    remote_sha=$(git -C "$pusher" rev-parse HEAD)
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    local local_sha
+    local_sha=$(git -C "$REPO_DIR" rev-parse main)
+    [ "$local_sha" = "$remote_sha" ]
+}
+
+@test "removes a branch deleted on the remote" {
+    create_remote_branch "feature/gone"
+    delete_remote_branch "feature/gone"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" branch --list "feature/gone"
+    [ -z "$output" ]
+}
+
+@test "keeps a branch still on the remote" {
+    create_remote_branch "feature/active"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" branch --list "feature/active"
+    [ -n "$output" ]
+}
+
+@test "removes worktree for a branch deleted on the remote" {
+    create_remote_branch "feature/gone"
+    local wt_path="$REPO_DIR/feature-gone"
+    git -C "$REPO_DIR" worktree add "$wt_path" "feature/gone"
+    delete_remote_branch "feature/gone"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    [ ! -d "$wt_path" ]
+    run git -C "$REPO_DIR" branch --list "feature/gone"
+    [ -z "$output" ]
+}
+
+@test "skips worktree removal for currently checked-out branch" {
+    create_remote_branch "feature/current"
+    local wt_path="$REPO_DIR/feature-current"
+    git -C "$REPO_DIR" worktree add "$wt_path" "feature/current"
+    delete_remote_branch "feature/current"
+
+    # Run the script from inside the worktree being deleted
+    run bash "$SCRIPT" -d "$wt_path"
+
+    [ "$status" -eq 0 ]
+    [ -d "$wt_path" ]
+}
+
+@test "scans subdirectories and finds bare repo" {
+    create_remote_branch "feature/gone"
+    delete_remote_branch "feature/gone"
+
+    run bash "$SCRIPT" -d "$BATS_TEST_TMPDIR"
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" branch --list "feature/gone"
+    [ -z "$output" ]
+}
+
+@test "-m flag is accepted and has no effect on bare repo" {
+    run bash "$SCRIPT" -d "$REPO_DIR" -m
+
+    [ "$status" -eq 0 ]
+}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Shared test helpers
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/git_cleanup.sh"
+
+# Create a bare remote repo and a local bare clone with a main worktree.
+# Sets: REMOTE_DIR, REPO_DIR, WORKTREE_DIR
+setup_bare_repo() {
+    local name="${1:-repo}"
+
+    REMOTE_DIR="$BATS_TEST_TMPDIR/remote-$name"
+    git init --bare "$REMOTE_DIR"
+
+    # Seed the remote with an initial commit so HEAD resolves
+    local seed="$BATS_TEST_TMPDIR/seed-$name"
+    git clone "$REMOTE_DIR" "$seed"
+    git -C "$seed" config user.email "test@test.com"
+    git -C "$seed" config user.name "Test"
+    git -C "$seed" config commit.gpgsign false
+    git -C "$seed" commit --allow-empty -m "init"
+    git -C "$seed" push origin main
+    rm -rf "$seed"
+
+    REPO_DIR="$BATS_TEST_TMPDIR/$name"
+    git clone --bare "$REMOTE_DIR" "$REPO_DIR"
+    git -C "$REPO_DIR" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+    git -C "$REPO_DIR" fetch origin
+
+    WORKTREE_DIR="$REPO_DIR/main"
+    git -C "$REPO_DIR" worktree add "$WORKTREE_DIR"
+    git -C "$WORKTREE_DIR" config user.email "test@test.com"
+    git -C "$WORKTREE_DIR" config user.name "Test"
+    git -C "$WORKTREE_DIR" config commit.gpgsign false
+}
+
+# Create a regular (non-bare) local repo cloned from a bare remote.
+# Sets: REMOTE_DIR, REPO_DIR
+setup_regular_repo() {
+    local name="${1:-repo}"
+
+    REMOTE_DIR="$BATS_TEST_TMPDIR/remote-$name"
+    git init --bare "$REMOTE_DIR"
+
+    local seed="$BATS_TEST_TMPDIR/seed-$name"
+    git clone "$REMOTE_DIR" "$seed"
+    git -C "$seed" config user.email "test@test.com"
+    git -C "$seed" config user.name "Test"
+    git -C "$seed" config commit.gpgsign false
+    git -C "$seed" commit --allow-empty -m "init"
+    git -C "$seed" push origin main
+    rm -rf "$seed"
+
+    REPO_DIR="$BATS_TEST_TMPDIR/$name"
+    git clone "$REMOTE_DIR" "$REPO_DIR"
+    git -C "$REPO_DIR" config user.email "test@test.com"
+    git -C "$REPO_DIR" config user.name "Test"
+    git -C "$REPO_DIR" config commit.gpgsign false
+}
+
+# Push a new branch to REMOTE_DIR and create it locally in REPO_DIR.
+create_remote_branch() {
+    local branch="$1"
+    local base_dir="${2:-${WORKTREE_DIR:-$REPO_DIR}}"
+    git -C "$base_dir" config commit.gpgsign false
+    git -C "$base_dir" checkout -b "$branch"
+    git -C "$base_dir" commit --allow-empty -m "work on $branch"
+    git -C "$base_dir" push -u origin "$branch"
+    git -C "$base_dir" checkout main 2>/dev/null || git -C "$base_dir" checkout -
+}
+
+# Delete a branch from REMOTE_DIR (simulates a merged/closed PR).
+delete_remote_branch() {
+    local branch="$1"
+    git -C "$REMOTE_DIR" branch -D "$branch"
+}

--- a/test/regular_repo.bats
+++ b/test/regular_repo.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Tests for regular (non-bare) repository cleanup
+
+setup() {
+    load helpers
+    setup_regular_repo
+}
+
+@test "removes a branch deleted on the remote" {
+    create_remote_branch "feature/gone"
+    delete_remote_branch "feature/gone"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" branch --list "feature/gone"
+    [ -z "$output" ]
+}
+
+@test "keeps a branch still on the remote" {
+    create_remote_branch "feature/active"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" branch --list "feature/active"
+    [ -n "$output" ]
+}
+
+@test "removes a merged branch" {
+    git -C "$REPO_DIR" checkout -b "feature/merged"
+    git -C "$REPO_DIR" commit --allow-empty -m "merged work"
+    git -C "$REPO_DIR" push origin "feature/merged"
+    git -C "$REPO_DIR" checkout main
+    git -C "$REPO_DIR" merge "feature/merged"
+    git -C "$REPO_DIR" push origin main
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" branch --list "feature/merged"
+    [ -z "$output" ]
+}
+
+@test "scans subdirectories when given a parent directory" {
+    create_remote_branch "feature/gone"
+    delete_remote_branch "feature/gone"
+
+    run bash "$SCRIPT" -d "$BATS_TEST_TMPDIR"
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" branch --list "feature/gone"
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

- Restructures `iterate_directories` to detect bare repos: a bare repo passed directly via `-d` is handled immediately; when scanning a projects directory, each subdirectory is checked via `--is-bare-repository` so bare repos are processed once (not once per linked worktree `.git` file)
- Adds `clean_bare_repository`: runs fetch, fast-forward main, prune worktrees, remove deleted worktrees/branches, remove merged branches, prune objects, and check stashes — omits `checkout_main_branch` and `remove_untracked` which don't apply to bare repos
- Adds `fast_forward_main`: uses `git fetch origin main:main --ff-only` to update main without requiring a checkout, safe in both bare repos and linked worktrees
- Fixes `remove_deleted_worktrees` to fall back to `--absolute-git-dir` when `--show-toplevel` fails in a bare repo context

Builds on top of `remove-deleted-worktrees` branch.

## Test plan

- [ ] Run `cleanup` against a projects directory containing both regular and bare repos — verify each is processed once
- [ ] Verify bare repo main is fast-forwarded after remote changes
- [ ] Verify stale worktrees with deleted remote branches are removed
- [ ] Verify `-m` flag (checkout main) is a no-op for bare repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)