### PR TITLE
fix(bare-repo): correct flag parsing, stash check, and untracked removal

### DIFF
--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -119,6 +119,7 @@ clean_bare_repository() {
     remove_deleted_worktrees
     remove_deleted_branches
     remove_merged_branches
+    remove_untracked
     prune_local_objects
     check_stashes
 }
@@ -308,7 +309,17 @@ remove_untracked() {
 # Check for stashes
 check_stashes() {
     echo "Checking for old stashes..."
-    if git stash list | grep -q 'stash@'; then
+    local stash_context="."
+    local is_bare
+    is_bare=$(git rev-parse --is-bare-repository 2>/dev/null)
+    if [ "$is_bare" = "true" ]; then
+        stash_context=$(git worktree list --porcelain 2>/dev/null | awk '
+            /^worktree / { path = substr($0, 10) }
+            /^branch /   { print path; exit }
+        ')
+        [ -z "$stash_context" ] && return
+    fi
+    if git -C "$stash_context" stash list 2>/dev/null | grep -q 'stash@'; then
         error_echo "Stashes found. Consider cleaning them manually."
     fi
 }

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -20,7 +20,7 @@ usage() {
 }
 
 # Parse command-line arguments
-while getopts "d:u:m" opt; do
+while getopts "d:um" opt; do
   case $opt in
     d) DIRECTORY="$OPTARG" ;;
     u) DELETE_UNTRACKED=true ;;

--- a/test/bare_repo.bats
+++ b/test/bare_repo.bats
@@ -90,3 +90,26 @@ setup() {
 
     [ "$status" -eq 0 ]
 }
+
+@test "warns about stashes in a worktree" {
+    echo "dirty" > "$WORKTREE_DIR/dirty-file"
+    git -C "$WORKTREE_DIR" add dirty-file
+    git -C "$WORKTREE_DIR" stash push -m "test stash"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Stashes found"* ]]
+}
+
+@test "-u flag removes untracked local branches" {
+    git -C "$WORKTREE_DIR" checkout -b local-only
+    git -C "$WORKTREE_DIR" commit --allow-empty -m "local work"
+    git -C "$WORKTREE_DIR" checkout main
+
+    run bash "$SCRIPT" -d "$REPO_DIR" -u
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" branch --list "local-only"
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

Three bugs in bare repository support, all found while running the cleanup script against a bare repo with worktrees.

## Linked issue

Closes #

## Type of change

- [x] Bug fix

## Details

**`getopts "d:u:m"` → `"d:um"`** — `-u` was incorrectly declared as requiring an argument. Any invocation passing `-u` would immediately hit the `*)` case and exit 1.

**`check_stashes` fails in bare repos** — `git stash list` requires a work tree and emits `fatal: this operation must be run in a work tree` when called from a bare repo context. The function now detects bare repos, finds the first linked worktree via `git worktree list --porcelain`, and runs the stash list from there. Silently skips if no worktree exists.

**`remove_untracked` missing from `clean_bare_repository`** — The `-u` flag had no effect on bare repos because `remove_untracked` was never called. Added it to `clean_bare_repository` to match `clean_repository` behaviour.

Two new tests in `test/bare_repo.bats` cover the stash warning and the `-u` flag path.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

All 13 tests pass (`bats test/`). The getopts fix is isolated in its own commit so it is easy to bisect if needed.