### PR TITLE
fix(nested-repos): do not process repos nested inside a working tree

### DIFF
--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -54,6 +54,20 @@ detect_main_branch() {
     fi
 }
 
+find_git_repo_roots() {
+    local base="$1"
+    local subdir
+    for subdir in "$base"/*/; do
+        [ -d "$subdir" ] || continue
+        subdir="${subdir%/}"
+        if [ -e "$subdir/.git" ]; then
+            echo "$subdir"
+        else
+            find_git_repo_roots "$subdir"
+        fi
+    done
+}
+
 # Function to iterate through directories and clean repositories
 iterate_directories() {
     info_echo "Checking projects in $DIRECTORY..."
@@ -75,10 +89,7 @@ iterate_directories() {
         return
     fi
 
-    # Process regular repos via their .git directory
-    find "$DIRECTORY" -type d -name ".git" | while read -r gitdir; do
-        local repo
-        repo=$(dirname "$gitdir")
+    find_git_repo_roots "$DIRECTORY" | while read -r repo; do
         cd "$repo" || continue
         info_echo "Processing $repo."
         clean_repository
@@ -146,7 +157,7 @@ checkout_main_branch() {
             error_echo "Failed to checkout the main branch."
         fi
     fi
-}   
+}
 
 # Fetch remotes and prune branches
 git_remotes() {

--- a/test/regular_repo.bats
+++ b/test/regular_repo.bats
@@ -52,3 +52,28 @@ setup() {
     run git -C "$REPO_DIR" branch --list "feature/gone"
     [ -z "$output" ]
 }
+
+@test "does not process a repo nested inside another repo's working tree" {
+    create_remote_branch "feature/outer"
+    delete_remote_branch "feature/outer"
+
+    # Simulate a tool that creates a git repo inside the outer repo's working tree,
+    # e.g. <repo>/<worktree>/parsimony/.git
+    local nested_repo="$REPO_DIR/parsimony"
+    git init "$nested_repo"
+    git -C "$nested_repo" config user.email "test@test.com"
+    git -C "$nested_repo" config user.name "Test"
+    git -C "$nested_repo" config commit.gpgsign false
+    git -C "$nested_repo" commit --allow-empty -m "init"
+    git -C "$nested_repo" checkout -b "feature/nested-branch"
+
+    run bash "$SCRIPT" -d "$BATS_TEST_TMPDIR"
+
+    [ "$status" -eq 0 ]
+    # Outer repo was cleaned
+    run git -C "$REPO_DIR" branch --list "feature/outer"
+    [ -z "$output" ]
+    # Nested repo was not processed — its branch is intact
+    run git -C "$nested_repo" branch --list "feature/nested-branch"
+    [ -n "$output" ]
+}


### PR DESCRIPTION
## Summary

When scanning a directory for git repositories, the script previously used `find` to locate all `.git` directories recursively. This caused it to descend into a repo's working tree and process any nested git repos it found there — including repos created by tools like parsimony that store git data inside another repo's working directory.

## Linked issue

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

Replaced the `find -name ".git"` scan with a recursive shell function `find_git_repo_roots` that walks subdirectories and yields a directory as a repo root the moment it finds a `.git` entry, without recursing further into it. This means once the outer repo boundary is reached, no inner repos in its working tree are ever visited.

The fix handles both `.git` directories (regular clones) and `.git` files (linked worktrees) via `[ -e "$subdir/.git" ]`.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [ ] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests where appropriate
- [ ] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

The previous `find`-based approach also had an intermediate fix (`-not -path '*/.git/*'`) that filtered out `.git` dirs nested inside another `.git/` directory. The recursive function makes that filter unnecessary — it never descends into `.git/` internals to begin with, and stops at working-tree boundaries too.