### PR TITLE
chore(audit): add detect-relevant-changes action and wire into CI workflows

### DIFF
--- a/.github/actions/detect-relevant-changes/action.yaml
+++ b/.github/actions/detect-relevant-changes/action.yaml
@@ -1,0 +1,65 @@
+name: 'Detect Relevant Changes'
+description: >
+  For pull_request events, sets relevant=true when any changed file matches one
+  of the supplied regex patterns. For any other event (push, schedule,
+  workflow_run, etc.) sets relevant=true unconditionally so heavy work is
+  preserved on main branch and scheduled runs.
+
+inputs:
+  patterns:
+    description: >
+      Multi-line list of JavaScript-compatible regex patterns matched against
+      the full path of each changed file. When empty, falls back to a default
+      set covering workflow and action edits.
+    required: false
+    default: ''
+
+outputs:
+  relevant:
+    description: 'true when heavy steps should run; false when the job should noop'
+    value: ${{ steps.detect.outputs.relevant }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: detect
+      uses: actions/github-script@v7
+      env:
+        PATTERNS: ${{ inputs.patterns }}
+      with:
+        script: |
+          const DEFAULT_PATTERNS = [
+            String.raw`^\.github/(workflows|actions)/`,
+            String.raw`^src/`,
+            String.raw`^lib/`,
+            String.raw`^tests?/`,
+            String.raw`^[^/]+\.(sh|bash|py|js|ts|go|rs|rb|java|kt)$`,
+          ];
+
+          if (context.eventName !== 'pull_request') {
+            core.info(`Event ${context.eventName}: running heavy work unconditionally.`);
+            core.setOutput('relevant', 'true');
+            return;
+          }
+
+          const raw = (process.env.PATTERNS || '').trim();
+          const sources = raw
+            ? raw.split('\n').map((s) => s.trim()).filter(Boolean)
+            : DEFAULT_PATTERNS;
+          const patterns = sources.map((s) => new RegExp(s));
+
+          const files = await github.paginate(github.rest.pulls.listFiles, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+            per_page: 100,
+          });
+
+          const hit = files.find((f) => patterns.some((p) => p.test(f.filename)));
+          if (hit) {
+            core.info(`Relevant change detected: ${hit.filename}`);
+            core.setOutput('relevant', 'true');
+          } else {
+            core.info(`No relevant changes in ${files.length} files.`);
+            core.setOutput('relevant', 'false');
+          }

--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -6,11 +6,12 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '23 4 * * 1' # weekly, Monday 04:23 UTC
+    - cron: "23 4 * * 1" # weekly, Monday 04:23 UTC
 
 permissions:
   actions: read
   contents: read
+  pull-requests: read
   security-events: write
 
 jobs:
@@ -29,6 +30,13 @@ jobs:
         #   swift                       -> macos-latest
         #     (Swift extractor only runs on macOS)
         #
+        # PATH FILTERS: The detect-relevant-changes action defaults to
+        # .github/workflows/** and .github/actions/**. When adding a
+        # language entry here, pass the relevant source patterns via the
+        # `patterns` input so the job noop's when nothing important changed.
+        # Per-language pattern selection can be done inline:
+        #   patterns: ${{ matrix.language == 'actions' && '...' || '...' }}
+        #
         # COMPILED LANGUAGES (swift, c-cpp, java-kotlin, csharp) require a
         # build step BEFORE 'Perform CodeQL analysis' so the extractor can
         # observe source compilation. Example for Swift:
@@ -43,20 +51,32 @@ jobs:
         #
         # Each include entry registers its own status check, named
         # `analyze (<language>, <runner>)`. Update branch protection
-        # rulesets to require those exact contexts.
+        # rulesets to require those exact contexts. Keep this matrix
+        # free of extra keys — anything added here becomes part of the
+        # status check name and would break the required-check contexts.
         include:
           - language: actions
             runner: ubuntu-latest
     steps:
+      # Steps are conditionally skipped rather than the job, so the
+      # matrix-expanded status check (e.g. "analyze (actions, ubuntu-latest)")
+      # is always registered. A job-level skip leaves that check unreported,
+      # which blocks PRs that require it.
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
+
+      - name: Detect relevant changes
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.35.5
+        if: steps.changes.outputs.relevant == 'true'
+        uses: github/codeql-action/init@v4.36.0
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4.35.5
+        if: steps.changes.outputs.relevant == 'true'
+        uses: github/codeql-action/analyze@v4.36.0
         with:
-          category: '/language:${{ matrix.language }}'
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -4,21 +4,32 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      # Steps are conditionally skipped rather than the job, so the status
+      # check is always registered. A job-level skip leaves it unreported,
+      # which blocks PRs that require it.
       - name: 'Checkout source code'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
+
+      - name: Detect relevant changes
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
 
       - name: 'Install actionlint'
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
 
       - name: 'Lint GitHub Actions workflows'
+        if: steps.changes.outputs.relevant == 'true'
         run: ./actionlint -color
 
       - name: 'Lint bash script with shellcheck'
+        if: steps.changes.outputs.relevant == 'true'
         run: shellcheck git_cleanup.sh

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -7,21 +7,31 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
+      # Steps are conditionally skipped rather than the job, so the status
+      # check is always registered. A job-level skip leaves it unreported,
+      # which blocks PRs that require it.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
+
+      - name: Detect relevant changes
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
 
       - name: Install bats
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           sudo apt-get update -q
           sudo apt-get install -y bats
 
       - name: Configure git for tests
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           git config --global user.email "ci@test.com"
           git config --global user.name "CI"
@@ -29,4 +39,5 @@ jobs:
           git config --global init.defaultBranch main
 
       - name: Run tests
+        if: steps.changes.outputs.relevant == 'true'
         run: bats test/

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,4 +1,7 @@
 name: Release
+# No paths filter: release-please must see every push to main so it can
+# parse conventional commits and drive version bumps. Filtering by path
+# would silently skip commits and break the release train.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

Adds a `detect-relevant-changes` composite action that gates heavy CI steps on whether a PR touches relevant files. On non-PR events (push to `main`, scheduled runs) it unconditionally returns `relevant=true` so those runs are never skipped. Integrates the action into the CodeQL, lint, and test workflows.

## Linked issue

Closes #

## Type of change

_Put an `x` in the boxes that apply._

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- New composite action at `.github/actions/detect-relevant-changes/action.yaml`. Checks the PR file list against configurable regex patterns; defaults cover `.github/(workflows|actions)/`, `src/`, `lib/`, `tests?/`, and root-level source files — most workflows need no custom `patterns` input.
- Steps are conditionally skipped rather than the whole job, keeping matrix-expanded status check names always registered (a job-level skip leaves the check unreported and would block required-check rules).
- `pull-requests: read` permission added to CodeQL, lint, and test workflows — required for the action's PR files API call.
- Action version bumps: `actions/checkout@v6.0.2`, `github/codeql-action@v4.36.0`.
- `release-please.yaml`: restored explanatory comment clarifying why the workflow has no `paths:` filter.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

_Put an `x` in the boxes that apply._

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

Workflow files validated by inspection; actionlint and CodeQL analysis will run on this PR.

## Reviewer notes

The `patterns` input on the action accepts newline-separated JavaScript regexes. Workflows that cover non-default file layouts (e.g. compiled languages with a `swift/` or `Sources/` tree) should pass explicit patterns rather than relying on the defaults.