### PR TITLE
chore(audit): sync files with repo-template-base

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -1,0 +1,36 @@
+## Summary
+
+Describe the bug being fixed and the impact of the fix.
+
+## Linked issue
+
+Closes #
+
+## Root cause
+
+What was wrong and why it produced the observed behavior.
+
+## Fix
+
+How the change addresses the root cause.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Unit tests pass locally
+- [ ] Added or updated a regression test
+- [ ] Manually verified the original bug no longer reproduces
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+- [ ] Breaking change (also apply the `breaking-change` label)
+
+## Reviewer notes
+
+Anything else that would help with review.

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,31 @@
+## Summary
+
+Describe the documentation or content change.
+
+## Linked issue
+
+Closes #
+
+## Scope
+
+What docs, pages, or content are updated.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Links checked
+- [ ] Rendered output reviewed (preview deploy or local build)
+- [ ] Spelling and grammar reviewed
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+
+## Reviewer notes
+
+Anything else worth highlighting.

--- a/.github/PULL_REQUEST_TEMPLATE/enhancement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/enhancement.md
@@ -1,0 +1,37 @@
+## Summary
+
+Describe the new capability or improvement and why it exists.
+
+## Linked issue
+
+Closes #
+
+## Approach
+
+How the feature is implemented. Call out important tradeoffs or alternatives considered.
+
+## Out of scope
+
+What this PR deliberately does not include.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Unit tests pass locally
+- [ ] Added or updated tests covering the new behavior
+- [ ] Manually verified the new behavior
+- [ ] Documentation updated where appropriate
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+- [ ] Breaking change (also apply the `breaking-change` label)
+
+## Reviewer notes
+
+Follow-up work, screenshots, or anything else worth highlighting.

--- a/.github/PULL_REQUEST_TEMPLATE/task.md
+++ b/.github/PULL_REQUEST_TEMPLATE/task.md
@@ -1,0 +1,36 @@
+## Summary
+
+Describe the maintenance, cleanup, refactor, or process change.
+
+## Linked issue
+
+Closes #
+
+## Motivation
+
+What pain, risk, inconsistency, or gap this addresses.
+
+## Changes
+
+The notable changes in this PR.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Unit tests pass locally
+- [ ] Behavior is unchanged (refactor) or covered by existing/new tests
+- [ ] Manually verified where applicable
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+- [ ] Breaking change (also apply the `breaking-change` label)
+
+## Reviewer notes
+
+Anything else worth highlighting.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+# Auto-applied PR labels by head-branch prefix.
+# See AGENTS.md for the branch-prefix convention.
+
+bug:
+  - head-branch: ['^(fix|bug|bugfix)-']
+
+enhancement:
+  - head-branch: ['^(feat|feature)-']
+
+task:
+  - head-branch: ['^(chore|refactor|test|build|ci|perf|style|task|maint|maintenance)-']
+
+documentation:
+  - head-branch: ['^(docs|doc)-']

--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -71,12 +71,12 @@ jobs:
 
       - name: Initialize CodeQL
         if: steps.changes.outputs.relevant == 'true'
-        uses: github/codeql-action/init@v4.36.1
+        uses: github/codeql-action/init@v4.36.2
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL analysis
         if: steps.changes.outputs.relevant == 'true'
-        uses: github/codeql-action/analyze@v4.36.1
+        uses: github/codeql-action/analyze@v4.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,0 +1,20 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels from branch prefix
+        uses: actions/labeler@v6.1.0
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,31 @@ Breaking changes: append `!` after the type (e.g., `feat!: rename public API`) o
 - Squash or rebase merges only — no merge commits.
 - Branches must be up to date with `main` before merging (`strict_required_status_checks_policy`).
 
+### Branch prefixes
+
+Name branches with a hyphen-delimited type prefix that mirrors the Conventional Commit type. The PR labeler workflow uses this prefix to apply the matching label automatically.
+
+| Prefix                                                                                              | Label           |
+| --------------------------------------------------------------------------------------------------- | --------------- |
+| `feat-`, `feature-`                                                                                 | `enhancement`   |
+| `fix-`, `bug-`, `bugfix-`                                                                           | `bug`           |
+| `docs-`, `doc-`                                                                                     | `documentation` |
+| `chore-`, `refactor-`, `test-`, `build-`, `ci-`, `perf-`, `style-`, `task-`, `maint-`, `maintenance-` | `task`        |
+
+Example: `feature-add-search`, `fix-login-redirect`, `docs-readme-update`.
+
+## Pull requests
+
+This repo ships four PR templates aligned with the issue templates: `bug.md`, `enhancement.md`, `task.md`, `documentation.md` in `.github/PULL_REQUEST_TEMPLATE/`.
+
+Pick one by appending `?template=<name>.md` to the compare URL, for example:
+
+```
+https://github.com/<owner>/<repo>/compare/main...<branch>?template=enhancement.md
+```
+
+Type labels (`bug`, `enhancement`, `task`, `documentation`) are applied automatically by the PR labeler workflow based on the branch prefix above. Apply `breaking-change` manually when a PR introduces a backwards-incompatible change.
+
 ## Required local checks
 
 Before pushing, the workflows that gate merge are `lint`, `test`, and `analyze` (CodeQL). Repos generated from `repo-template-astro` have lint and test commands wired into `package.json`; reach for those first.


### PR DESCRIPTION
## Summary

Sync this repo against `richwklein/repo-template-base` after running `/repo-template-audit`. Adds the PR labeler workflow + four type-specific PR templates, restores the branch-prefix / PR-template guidance in `AGENTS.md`, and bumps the CodeQL action pins.

## Linked issue

Closes #

## Motivation

Template drift had accumulated: the PR labeling system (templates + workflow + labeler config + AGENTS guidance) was never adopted, and `code-codeql.yaml` lagged the template by one patch version.

## Changes

- Added `.github/PULL_REQUEST_TEMPLATE/{bug,documentation,enhancement,task}.md`.
- Added `.github/labeler.yml` mapping branch prefixes (`fix-`, `feat-`, `chore-`, `docs-`, ...) to PR labels.
- Added `.github/workflows/pr-labeler.yaml` running `actions/labeler@v6.1.0` on PR open/sync/edit.
- Restored the **Branch prefixes** and **Pull requests** sections in `AGENTS.md`.
- Bumped `github/codeql-action/{init,analyze}` from `v4.36.1` to `v4.36.2` in `.github/workflows/code-codeql.yaml`.
- Kept the repo-local extra patterns (`src/`, `lib/`, `tests?/`, top-level source extensions) in `.github/actions/detect-relevant-changes/action.yaml` — intentional divergence for this shell-script repo.

## Validation

- [x] `/repo-template-audit richwklein/repo-template-base` re-run after changes (file drift remaining: only `CHANGELOG.md`, which is expected).
- [ ] CI (`lint`, `test`, `analyze`) green on this PR.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change

## Reviewer notes

The `pr-labeler` workflow uses `pull_request_target` and writes labels — that's why it lives in this PR rather than being applied by a downstream contributor. This PR's own branch (`chore-template-audit`) will match the `task` rule once the workflow lands on `main`.