### PR TITLE
feat(worktrees): remove merged worktrees and repair branch cleanup gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ The `git_cleanup.sh` script is designed to help you clean up your local Git repo
 - Fetches updates from remote repositories and prunes any remote-tracking references that no longer exist on the remote.
 - Fast-forwards the main branch to the latest remote commit without requiring a checkout. *(bare repos)*
 - Optionally checks out the main branch before cleanup. [-m] *(regular repos only)*
-- Removes linked worktrees whose checked-out branch has been deleted on the remote.
+- Removes linked worktrees whose checked-out branch has been deleted on the remote or merged into the main branch.
 - Removes local branches that have been deleted on the remote.
-- Removes local branches that have been merged into the main branch.
+- Removes local branches that have been merged into the main branch (checked against the remote-tracking ref when available, so a stale local main does not hide fresh merges).
 - Skips branches that are currently checked out in any linked Git worktree.
 - Prunes stale Git worktree metadata.
 - Prunes orphaned objects from the local repository.
 - Checks for old stashes and notifies if any are found.
-- Optionally removes any untracked branches. [-u] *(regular repos only)*
+- Optionally removes untracked branches — local branches that do not track any remote branch. [-u]
 
 ## Usage
 
@@ -27,7 +27,7 @@ Usage: ./git_cleanup.sh [-d directory] [-u] [-m]
 ```
 
 - -d directory: Specify the directory to clean up. Defaults to the current directory (.).
-- -u: Removes untracked branches.
+- -u: Removes local branches that do not track any remote branch. The main branch and the currently checked-out branch are never removed.
 - -m: Checks out the main branch before cleanup when possible.
 
 ### Behavior
@@ -38,11 +38,13 @@ If the specified directory is a bare repository, the script cleans it directly. 
 
 **Bare repositories**
 
-Bare repos have no working tree, so `checkout_main_branch` and `remove_untracked` are skipped. Instead, the script fast-forwards the main branch directly using `git fetch origin main:main --ff-only`, keeping it current without requiring a checkout. The `-m` flag is accepted but has no effect on bare repos.
+Bare repos have no working tree, so `checkout_main_branch` is skipped. Instead, the script fast-forwards the main branch directly using a fetch refspec (`git fetch origin main:main`), keeping it current without requiring a checkout; when the main branch is checked out in a linked worktree, the script pulls from that worktree instead. The `-m` flag is accepted but has no effect on bare repos.
+
+A stock `git clone --bare` has no fetch refspec, so remote-tracking refs never exist and deleted remote branches cannot be detected. The script adds the standard refspec (`+refs/heads/*:refs/remotes/<remote>/*`) to any remote missing one before fetching.
 
 **Worktree-aware branch deletion**
 
-When a linked worktree has a checked-out branch whose remote tracking branch has been deleted, the script removes that worktree and deletes the local branch. If the deleted branch is checked out in the current worktree, the script skips it because removing the directory it is running from is unsafe.
+When a linked worktree has a checked-out branch whose remote tracking branch has been deleted, or that has been merged into the main branch, the script removes that worktree and deletes the local branch. Worktrees with uncommitted or untracked changes are left in place. If the affected branch is checked out in the current worktree, the script skips it because removing the directory it is running from is unsafe.
 
 When deleting other branches, the script skips branches that are checked out by any worktree because Git does not allow those branches to be deleted. When `-m` is used from a worktree, the script also skips checking out the main branch if that branch is already checked out by another worktree.
 

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -248,10 +248,9 @@ worktree_branches() {
     '
 }
 
-remove_deleted_worktrees() {
-    echo "Removing worktrees with deleted remote tracking..."
-    local branches
-    branches=$(gone_tracking_branches)
+# Remove worktrees whose branch is in the given list, deleting the branch after
+remove_worktrees_for_branches() {
+    local branches="$1"
 
     if [[ -z "$branches" ]]; then
         return
@@ -270,7 +269,7 @@ remove_deleted_worktrees() {
             continue
         fi
 
-        echo "Removing worktree $worktree for deleted branch $branch..."
+        echo "Removing worktree $worktree for branch $branch..."
         if git worktree remove "$worktree"; then
             git branch -D "$branch"
         else
@@ -279,11 +278,21 @@ remove_deleted_worktrees() {
     done
 }
 
+remove_deleted_worktrees() {
+    echo "Removing worktrees with deleted remote tracking..."
+    remove_worktrees_for_branches "$(gone_tracking_branches)"
+}
+
 # Function to delete branches
 delete_branches() {
     local branches="$1"
     if [[ -n "$branches" ]]; then
         echo "$branches" | while read -r branch; do
+            # Branch may already be gone if its worktree was removed
+            if ! git show-ref --verify --quiet "refs/heads/$branch"; then
+                continue
+            fi
+
             if is_branch_checked_out "$branch"; then
                 error_echo "Skipping $branch because it is checked out in a worktree."
                 continue
@@ -311,6 +320,7 @@ remove_merged_branches() {
     current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
     local branches
     branches=$(git branch --format "%(refname:short)" --merged "$main_branch" | grep -Fvx -e "$main_branch" -e "$current_branch")
+    remove_worktrees_for_branches "$branches"
     delete_branches "$branches"
 }
 

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -124,6 +124,7 @@ clean_repository() {
 
 # Function to clean a bare repository
 clean_bare_repository() {
+    ensure_fetch_refspecs
     fetch_remotes
     fast_forward_main
     prune_worktrees
@@ -162,6 +163,18 @@ checkout_main_branch() {
 # Fetch remotes and prune branches
 git_remotes() {
     git remote 2>/dev/null
+}
+
+# A stock 'git clone --bare' has no fetch refspec, so remote-tracking refs
+# never exist and gone-upstream detection cannot find deleted branches.
+ensure_fetch_refspecs() {
+    local remote
+    for remote in $(git_remotes); do
+        if [ -z "$(git config --get-all "remote.$remote.fetch")" ]; then
+            info_echo "Adding missing fetch refspec for remote $remote."
+            git config "remote.$remote.fetch" "+refs/heads/*:refs/remotes/$remote/*"
+        fi
+    done
 }
 
 fetch_remotes() {

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -166,8 +166,7 @@ git_remotes() {
 
 fetch_remotes() {
     echo "Fetching remote changes and pruning removed branches..."
-    # shellcheck disable=SC2046 # intentional word-splitting on remote names
-    git fetch --prune $(git_remotes)
+    git fetch --all --prune
 }
 
 # Fast-forward main branch without checking it out (safe in bare repos and worktrees)
@@ -187,7 +186,8 @@ fast_forward_main() {
         git -C "$main_worktree" pull --ff-only origin "$main_branch" 2>/dev/null \
             || error_echo "Could not fast-forward $main_branch (diverged or up to date)."
     else
-        git fetch origin "$main_branch:$main_branch" --ff-only 2>/dev/null \
+        # A refspec without a leading + already refuses non-fast-forward updates.
+        git fetch origin "$main_branch:$main_branch" 2>/dev/null \
             || error_echo "Could not fast-forward $main_branch (diverged or up to date)."
     fi
 }

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -338,12 +338,18 @@ prune_local_objects() {
     git prune --progress
 }
 
-# Remove untracked branches
+# Remove local branches that do not track any remote branch
 remove_untracked() {
     if [ "$DELETE_UNTRACKED" = true ]; then
         echo "Removing untracked branches..."
+        local main_branch
+        main_branch=$(detect_main_branch)
+        local current_branch
+        current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
         local branches
-        branches=$(git branch --format "%(refname:short)" --no-merged)
+        branches=$(git branch --format "%(refname:short) %(upstream)" \
+            | awk 'NF == 1 {print $1}' \
+            | grep -Fvx -e "$main_branch" -e "$current_branch")
         delete_branches "$branches"
     fi
 }

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -316,10 +316,18 @@ remove_merged_branches() {
     echo "Removing merged local branches..."
     local main_branch
     main_branch=$(detect_main_branch)
+
+    # Prefer the remote-tracking ref as the merge base — it is current right
+    # after the fetch, while local main may be stale.
+    local merge_base="$main_branch"
+    if git show-ref --verify --quiet "refs/remotes/origin/$main_branch"; then
+        merge_base="origin/$main_branch"
+    fi
+
     local current_branch
     current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
     local branches
-    branches=$(git branch --format "%(refname:short)" --merged "$main_branch" | grep -Fvx -e "$main_branch" -e "$current_branch")
+    branches=$(git branch --format "%(refname:short)" --merged "$merge_base" | grep -Fvx -e "$main_branch" -e "$current_branch")
     remove_worktrees_for_branches "$branches"
     delete_branches "$branches"
 }

--- a/test/bare_repo.bats
+++ b/test/bare_repo.bats
@@ -83,6 +83,26 @@ setup() {
     [ -z "$output" ]
 }
 
+@test "adds fetch refspec to a stock bare clone so gone branches are cleaned" {
+    create_remote_branch "feature/gone"
+    delete_remote_branch "feature/gone"
+
+    # Simulate a stock 'git clone --bare': no fetch refspec, no remote-tracking refs
+    git -C "$REPO_DIR" config --unset-all remote.origin.fetch
+    git -C "$REPO_DIR" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+    git -C "$REPO_DIR" for-each-ref 'refs/remotes' --format='%(refname)' | while read -r ref; do
+        git -C "$REPO_DIR" update-ref -d "$ref"
+    done
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" config --get remote.origin.fetch
+    [ -n "$output" ]
+    run git -C "$REPO_DIR" branch --list "feature/gone"
+    [ -z "$output" ]
+}
+
 @test "prunes gone branches when multiple remotes exist" {
     create_remote_branch "feature/gone"
     delete_remote_branch "feature/gone"

--- a/test/bare_repo.bats
+++ b/test/bare_repo.bats
@@ -26,6 +26,28 @@ setup() {
     [ "$local_sha" = "$remote_sha" ]
 }
 
+@test "fast-forwards main when it has no worktree" {
+    git -C "$REPO_DIR" worktree remove "$WORKTREE_DIR"
+
+    # Push a new commit to remote from a separate clone
+    local pusher="$BATS_TEST_TMPDIR/pusher"
+    git clone "$REMOTE_DIR" "$pusher"
+    git -C "$pusher" config user.email "test@test.com"
+    git -C "$pusher" config user.name "Test"
+    git -C "$pusher" config commit.gpgsign false
+    git -C "$pusher" commit --allow-empty -m "remote advance"
+    git -C "$pusher" push origin main
+    local remote_sha
+    remote_sha=$(git -C "$pusher" rev-parse HEAD)
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    local local_sha
+    local_sha=$(git -C "$REPO_DIR" rev-parse main)
+    [ "$local_sha" = "$remote_sha" ]
+}
+
 @test "removes a branch deleted on the remote" {
     create_remote_branch "feature/gone"
     delete_remote_branch "feature/gone"
@@ -57,6 +79,18 @@ setup() {
 
     [ "$status" -eq 0 ]
     [ ! -d "$wt_path" ]
+    run git -C "$REPO_DIR" branch --list "feature/gone"
+    [ -z "$output" ]
+}
+
+@test "prunes gone branches when multiple remotes exist" {
+    create_remote_branch "feature/gone"
+    delete_remote_branch "feature/gone"
+    git -C "$REPO_DIR" remote add backup "$REMOTE_DIR"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
     run git -C "$REPO_DIR" branch --list "feature/gone"
     [ -z "$output" ]
 }

--- a/test/bare_repo.bats
+++ b/test/bare_repo.bats
@@ -83,6 +83,37 @@ setup() {
     [ -z "$output" ]
 }
 
+@test "removes worktree for a merged branch still on the remote" {
+    create_remote_branch "feature/merged"
+    git -C "$WORKTREE_DIR" merge "feature/merged"
+    git -C "$WORKTREE_DIR" push origin main
+    local wt_path="$REPO_DIR/feature-merged"
+    git -C "$REPO_DIR" worktree add "$wt_path" "feature/merged"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    [ ! -d "$wt_path" ]
+    run git -C "$REPO_DIR" branch --list "feature/merged"
+    [ -z "$output" ]
+}
+
+@test "keeps a dirty worktree for a merged branch" {
+    create_remote_branch "feature/merged"
+    git -C "$WORKTREE_DIR" merge "feature/merged"
+    git -C "$WORKTREE_DIR" push origin main
+    local wt_path="$REPO_DIR/feature-merged"
+    git -C "$REPO_DIR" worktree add "$wt_path" "feature/merged"
+    echo "uncommitted" > "$wt_path/leftover"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    [ -d "$wt_path" ]
+    run git -C "$REPO_DIR" branch --list "feature/merged"
+    [ -n "$output" ]
+}
+
 @test "adds fetch refspec to a stock bare clone so gone branches are cleaned" {
     create_remote_branch "feature/gone"
     delete_remote_branch "feature/gone"

--- a/test/regular_repo.bats
+++ b/test/regular_repo.bats
@@ -62,6 +62,28 @@ setup() {
     [ -z "$output" ]
 }
 
+@test "-u removes only branches without an upstream" {
+    create_remote_branch "feature/active"
+    git -C "$REPO_DIR" commit --allow-empty -m "main advance"
+    git -C "$REPO_DIR" checkout -b scratch main^
+    git -C "$REPO_DIR" commit --allow-empty -m "scratch work"
+    git -C "$REPO_DIR" checkout -b wip main^
+
+    run bash "$SCRIPT" -d "$REPO_DIR" -u
+
+    [ "$status" -eq 0 ]
+    # untracked branch is removed
+    run git -C "$REPO_DIR" branch --list "scratch"
+    [ -z "$output" ]
+    # main, the current branch, and tracked branches survive
+    run git -C "$REPO_DIR" branch --list "main"
+    [ -n "$output" ]
+    run git -C "$REPO_DIR" branch --list "wip"
+    [ -n "$output" ]
+    run git -C "$REPO_DIR" branch --list "feature/active"
+    [ -n "$output" ]
+}
+
 @test "scans subdirectories when given a parent directory" {
     create_remote_branch "feature/gone"
     delete_remote_branch "feature/gone"

--- a/test/regular_repo.bats
+++ b/test/regular_repo.bats
@@ -42,6 +42,26 @@ setup() {
     [ -z "$output" ]
 }
 
+@test "removes a branch merged on the remote when local main is stale" {
+    create_remote_branch "feature/merged"
+
+    # Merge the branch into main on the remote from a separate clone,
+    # leaving local main behind and the remote branch in place
+    local pusher="$BATS_TEST_TMPDIR/pusher"
+    git clone "$REMOTE_DIR" "$pusher"
+    git -C "$pusher" config user.email "test@test.com"
+    git -C "$pusher" config user.name "Test"
+    git -C "$pusher" config commit.gpgsign false
+    git -C "$pusher" merge "origin/feature/merged"
+    git -C "$pusher" push origin main
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    run git -C "$REPO_DIR" branch --list "feature/merged"
+    [ -z "$output" ]
+}
+
 @test "scans subdirectories when given a parent directory" {
     create_remote_branch "feature/gone"
     delete_remote_branch "feature/gone"


### PR DESCRIPTION
## Summary

A review of the worktree cleanup logic (bare-clone workflow and regular checkouts) found that merged worktrees were only ever cleaned when their remote branch had been deleted, and several supporting steps were silently broken. This PR makes merged-branch cleanup actually remove worktrees, repairs the fetch/fast-forward plumbing that feeds the detection, and fixes the `-u` flag so it can no longer delete local `main` or actively tracked branches.

## Linked issue

No linked issue — found during a manual review of `git_cleanup.sh`.

## Root cause

- `remove_merged_branches` handed merged branches to `delete_branches`, which skips any branch checked out in a worktree — so a merged branch with a live worktree was skipped forever; nothing removed the worktree.
- `git fetch origin main:main --ff-only` is invalid (`--ff-only` belongs to `git pull`), so in bare repos with no main worktree the local main never advanced; the usage error was hidden by `2>/dev/null`.
- Merged detection compared against local main, which nothing updates in regular repos, so merges since the last pull were invisible.
- A stock `git clone --bare` has no fetch refspec, so remote-tracking refs never exist and gone-upstream detection finds nothing.
- `git fetch --prune remote1 remote2` treats the second remote as a refspec.
- `-u` used `git branch --no-merged` relative to HEAD — unrelated to tracking — and could delete local `main` and tracked branches when run from a feature branch.

## Fix

- Extract the worktree-removal loop into `remove_worktrees_for_branches` and run it for merged branches too, keeping existing protections (current worktree refused, dirty worktrees left in place); guard `delete_branches` against branches already deleted by the worktree pass.
- Drop the invalid `--ff-only` flag — a refspec without a leading `+` is already fast-forward-only.
- Use `origin/<main>` as the merge base when it exists (fresh right after the fetch), falling back to local main.
- Auto-add the standard fetch refspec to remotes missing one in the bare-repo path.
- Fetch with `--all --prune`.
- Redefine `-u` as "branches with no configured upstream", never touching main or the current branch.

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

`shellcheck` clean; all 21 bats tests pass (7 new regression tests across `bare_repo.bats` and `regular_repo.bats`, one per fix). Each failure mode was also reproduced and re-verified in sandbox repos covering bare-clone and regular-checkout scenarios (squash-merge + branch delete, merge with branch kept, stale local main, dirty worktrees, stock bare clone, multiple remotes, `-u` from a feature branch).

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- `-u` semantics intentionally changed: it previously deleted branches not merged into HEAD; it now deletes branches with no upstream. This matches the README's long-standing description of the flag.
- `ensure_fetch_refspecs` writes `remote.<name>.fetch` config in bare repos that lack one — a deliberate, logged side effect required for gone-branch detection.
- The merge base prefers the `origin` remote specifically; other remote names fall back to local main.
- README updated to match, including removing the incorrect claim that `remove_untracked` is skipped in bare repos.
- Commits are split one concern per commit if you prefer reviewing sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)