### PR TITLE
feat: highlight git errors and warnings in command output

### DIFF
--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -404,3 +404,5 @@ check_stashes() {
 }
 
 iterate_directories
+
+info_echo "Cleanup complete."

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -22,6 +22,28 @@ verbose_echo() {
     fi
 }
 
+# Colorize git diagnostic lines from a command's combined output.
+# error:/fatal: (incl. remote: variants) -> RED; warning: -> YELLOW.
+highlight_stream() {
+    local line
+    while IFS= read -r line || [ -n "$line" ]; do
+        if [[ "$line" =~ ^(remote:[[:space:]]*)?(error|fatal): ]]; then
+            printf "%b%s%b\n" "$RED" "$line" "$NO_COLOR" >&2
+        elif [[ "$line" =~ ^(remote:[[:space:]]*)?warning: ]]; then
+            printf "%b%s%b\n" "$YELLOW" "$line" "$NO_COLOR" >&2
+        else
+            printf "%s\n" "$line"
+        fi
+    done
+}
+
+# Run a command, streaming its combined output through the error highlighter
+# while preserving the command's own exit status.
+run_highlighted() (
+    set -o pipefail
+    "$@" 2>&1 | highlight_stream
+)
+
 usage() {
     echo "Usage: $0 [-d directory] [-u] [-m] [-q]"
 }
@@ -163,7 +185,7 @@ checkout_main_branch() {
             return
         fi
 
-        if ! git checkout "$main_branch"; then
+        if ! run_highlighted git checkout "$main_branch"; then
             error_echo "Failed to checkout the main branch."
         fi
     fi
@@ -188,7 +210,7 @@ ensure_fetch_refspecs() {
 
 fetch_remotes() {
     verbose_echo "Fetching remote changes and pruning removed branches..."
-    git fetch --all --prune
+    run_highlighted git fetch --all --prune
 }
 
 # Fast-forward main branch without checking it out (safe in bare repos and worktrees)
@@ -218,7 +240,7 @@ fast_forward_main() {
 prune_worktrees() {
     if git worktree list >/dev/null 2>&1; then
         verbose_echo "Pruning stale worktree metadata..."
-        git worktree prune
+        run_highlighted git worktree prune
     fi
 }
 
@@ -279,8 +301,8 @@ remove_worktrees_for_branches() {
         fi
 
         verbose_echo "Removing worktree $worktree for branch $branch..."
-        if git worktree remove "$worktree"; then
-            git branch -D "$branch"
+        if run_highlighted git worktree remove "$worktree"; then
+            run_highlighted git branch -D "$branch"
         else
             error_echo "Failed to remove worktree $worktree for branch $branch."
         fi
@@ -307,7 +329,7 @@ delete_branches() {
                 continue
             fi
 
-            git branch -D "$branch"
+            run_highlighted git branch -D "$branch"
         done
     fi
 }
@@ -344,7 +366,7 @@ remove_merged_branches() {
 # Prune orphaned objects
 prune_local_objects() {
     verbose_echo "Removing orphaned objects..."
-    git prune --progress
+    run_highlighted git prune --progress
 }
 
 # Remove local branches that do not track any remote branch

--- a/test/bare_repo.bats
+++ b/test/bare_repo.bats
@@ -114,6 +114,22 @@ setup() {
     [ -n "$output" ]
 }
 
+@test "highlights git error output in the error color" {
+    create_remote_branch "feature/merged"
+    git -C "$WORKTREE_DIR" merge "feature/merged"
+    git -C "$WORKTREE_DIR" push origin main
+    local wt_path="$REPO_DIR/feature-merged"
+    git -C "$REPO_DIR" worktree add "$wt_path" "feature/merged"
+    echo "uncommitted" > "$wt_path/leftover"
+
+    run bash "$SCRIPT" -d "$REPO_DIR"
+
+    [ "$status" -eq 0 ]
+    # git's own "fatal:" diagnostic is wrapped in the RED color code
+    local red=$'\033[0;31m'
+    [[ "$output" == *"${red}fatal:"* ]]
+}
+
 @test "adds fetch refspec to a stock bare clone so gone branches are cleaned" {
     create_remote_branch "feature/gone"
     delete_remote_branch "feature/gone"


### PR DESCRIPTION
## Summary

Git diagnostics from the commands the script runs (fetch, checkout, worktree remove, branch delete, prune) previously blended into normal output uncolored, making failures easy to miss. This PR colorizes them using the script's existing color scheme — `error:`/`fatal:` in red, `warning:` in yellow — and adds a top-level "Cleanup complete." message so it's clear when a run finishes.

## Linked issue

Closes #7

## Approach

- Added `highlight_stream`, a filter that reads a command's combined output line by line and recolors git diagnostics: `error:`/`fatal:` (including `remote:` variants) in red, `warning:` in yellow (both to stderr, matching `error_echo`). All other lines pass through unchanged.
- Added `run_highlighted`, a subshell wrapper that pipes a command through `highlight_stream` with `pipefail` enabled locally, so the command's own exit status is preserved for callers that check it (e.g. `if ! ... checkout`, `worktree remove`) without leaking `pipefail` globally.
- Wrapped the six user-facing action commands. Query commands whose stdout is parsed are deliberately left untouched, and `fast_forward_main` keeps its intentional stderr suppression and friendly error message.
- Added a `Cleanup complete.` message via `info_echo`, so it stays visible under `-q` like the other top-level status lines.

Git disables its own auto-coloring under a pipe, so diagnostics arrive as plain prefixed text — matching is reliable with no risk of double-coloring.

## Out of scope

- Non-prefixed git errors (e.g. multi-line "Your local changes would be overwritten" bodies) are not specially detected — only the reliably-prefixed diagnostic lines.
- No TTY detection / `NO_COLOR` handling was added; this matches the script's existing always-on color behavior.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [x] Manually verified the new behavior
- [ ] Documentation updated where appropriate

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

New bats test `highlights git error output in the error color` forces `git worktree remove` to fail on a dirty merged worktree and asserts the resulting `fatal:` line carries the red color code. Manually verified against a real bare repo with a dirty worktree — the `fatal:` line renders red while normal output stays default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)