### PR TITLE
fix: force-remove dirty merged worktrees under -u and accept positional dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ The `git_cleanup.sh` script is designed to help you clean up your local Git repo
 You can run the script with the following options:
 
 ```sh
-Usage: ./git_cleanup.sh [-d directory] [-u] [-m] [-q]
+Usage: ./git_cleanup.sh [-u] [-m] [-q] [-d directory | directory]
 ```
 
-- -d directory: Specify the directory to clean up. Defaults to the current directory (.).
-- -u: Removes local branches that do not track any remote branch. The main branch and the currently checked-out branch are never removed.
+- -d directory: Specify the directory to clean up. Defaults to the current directory (.). The directory may also be given as a bare positional argument (e.g. `./git_cleanup.sh .`), and flags may appear in any order.
+- -u: Removes local branches that do not track any remote branch, and force-removes worktrees that still contain modified or untracked files. The main branch and the currently checked-out branch are never removed.
 - -m: Checks out the main branch before cleanup when possible.
 - -q: Quiet mode. Suppresses sub-operation progress messages; only top-level repository headers and errors are printed.
 

--- a/git_cleanup.sh
+++ b/git_cleanup.sh
@@ -45,21 +45,28 @@ run_highlighted() (
 )
 
 usage() {
-    echo "Usage: $0 [-d directory] [-u] [-m] [-q]"
+    echo "Usage: $0 [-u] [-m] [-q] [-d directory | directory]"
 }
 
-# Parse command-line arguments
-while getopts "d:umq" opt; do
-  case $opt in
-    d) DIRECTORY="$OPTARG" ;;
-    u) DELETE_UNTRACKED=true ;;
-    m) CHECKOUT_MAIN=true ;;
-    q) QUIET=true ;;
-    *)
-      usage
-      exit 1
-      ;;
-  esac
+# Parse command-line arguments. Unlike getopts, this accepts a positional
+# directory and allows flags to appear in any order (e.g. both "-d . -u" and
+# ". -u" work); a bare path is equivalent to -d.
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -d)
+            [ $# -ge 2 ] || { usage; exit 1; }
+            DIRECTORY="$2"
+            shift 2
+            ;;
+        -d*) DIRECTORY="${1#-d}"; shift ;;
+        -u) DELETE_UNTRACKED=true; shift ;;
+        -m) CHECKOUT_MAIN=true; shift ;;
+        -q) QUIET=true; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) usage; exit 1 ;;
+        *) DIRECTORY="$1"; shift ;;
+    esac
 done
 
 # Default values
@@ -290,6 +297,14 @@ remove_worktrees_for_branches() {
     local current_worktree
     current_worktree=$(git rev-parse --show-toplevel 2>/dev/null || git rev-parse --absolute-git-dir 2>/dev/null)
 
+    # git worktree remove refuses a worktree with modified or untracked files.
+    # Only override that with --force when the user opted into -u; otherwise
+    # such worktrees are reported and left in place.
+    local -a remove_opts=()
+    if [ "$DELETE_UNTRACKED" = true ]; then
+        remove_opts=(--force)
+    fi
+
     worktree_branches | while IFS=$'\t' read -r worktree branch; do
         if ! echo "$branches" | grep -Fxq "$branch"; then
             continue
@@ -301,8 +316,10 @@ remove_worktrees_for_branches() {
         fi
 
         verbose_echo "Removing worktree $worktree for branch $branch..."
-        if run_highlighted git worktree remove "$worktree"; then
+        if run_highlighted git worktree remove "${remove_opts[@]}" "$worktree"; then
             run_highlighted git branch -D "$branch"
+        elif [ "$DELETE_UNTRACKED" != true ]; then
+            error_echo "Failed to remove worktree $worktree for branch $branch (has modified or untracked files; rerun with -u to force)."
         else
             error_echo "Failed to remove worktree $worktree for branch $branch."
         fi

--- a/test/bare_repo.bats
+++ b/test/bare_repo.bats
@@ -114,6 +114,36 @@ setup() {
     [ -n "$output" ]
 }
 
+@test "-u force-removes a dirty worktree for a merged branch" {
+    create_remote_branch "feature/merged"
+    git -C "$WORKTREE_DIR" merge "feature/merged"
+    git -C "$WORKTREE_DIR" push origin main
+    local wt_path="$REPO_DIR/feature-merged"
+    git -C "$REPO_DIR" worktree add "$wt_path" "feature/merged"
+    echo "uncommitted" > "$wt_path/leftover"
+
+    run bash "$SCRIPT" -d "$REPO_DIR" -u
+
+    [ "$status" -eq 0 ]
+    [ ! -d "$wt_path" ]
+    run git -C "$REPO_DIR" branch --list "feature/merged"
+    [ -z "$output" ]
+}
+
+@test "accepts the directory as a positional argument with flags in any order" {
+    create_remote_branch "feature/merged"
+    git -C "$WORKTREE_DIR" merge "feature/merged"
+    git -C "$WORKTREE_DIR" push origin main
+    local wt_path="$REPO_DIR/feature-merged"
+    git -C "$REPO_DIR" worktree add "$wt_path" "feature/merged"
+    echo "uncommitted" > "$wt_path/leftover"
+
+    run bash "$SCRIPT" "$REPO_DIR" -u
+
+    [ "$status" -eq 0 ]
+    [ ! -d "$wt_path" ]
+}
+
 @test "highlights git error output in the error color" {
     create_remote_branch "feature/merged"
     git -C "$WORKTREE_DIR" merge "feature/merged"


### PR DESCRIPTION
## Summary

Cleanup left merged/gone worktrees behind with a wall of `fatal: '...' contains modified or untracked files, use --force to delete it` errors, and passing `-u` didn't help. This makes `-u` actually force-remove those worktrees and fixes the argument parsing so the flag is honored regardless of position.

## Linked issue

Closes #<!-- no tracking issue -->

## Root cause

Two separate problems:

1. **Worktree removal never forced.** `remove_worktrees_for_branches` ran `git worktree remove` without `--force`. `git worktree remove` refuses any worktree that contains modified or untracked files (in taskmato's case, an untracked `.agents/` skills directory in every sibling worktree), so every merged/gone worktree failed with a fatal even though its branch was correctly detected as removable.
2. **`-u` silently dropped.** Argument parsing used `getopts`, which stops at the first non-option word. Invoking `git_cleanup.sh . -u` made `getopts` stop at the positional `.`, so `-u` was never processed and `DELETE_UNTRACKED` stayed `false`. The bare `.` was also ignored entirely — `git_cleanup.sh .` only worked because `DIRECTORY` defaults to `.`.

## Fix

- Gate `git worktree remove --force` on the existing `-u` flag. The default stays safe (dirty worktrees are reported and left in place); `-u` opts into force-removing them along with their gone/merged branches. The failure message now explains the cause and points at `-u`.
- Replace `getopts` with a manual parser that accepts the directory as a positional argument and allows flags in any order, so both `-d . -u` and `. -u` work.
- Update README usage and `-u` description accordingly.

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated a regression test
- [ ] Manually verified the original bug no longer reproduces

`shellcheck` is clean and all 28 bats tests pass. Added regression tests for `-u` force-removing a dirty merged worktree and for positional-directory-with-flags parsing. Not yet re-run end-to-end against the taskmato bare checkout.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

Note: `-u` now also authorizes force-removal of dirty worktrees, slightly broadening its prior "delete non-tracking branches" meaning. Not backwards-incompatible, but worth a reviewer's attention.

## Reviewer notes

Switching from `getopts` to the manual parser drops support for bundled short flags (e.g. `-uq` must now be `-u -q`). Happy to restore bundling or split the worktree-force behavior onto a distinct flag if either is preferred.
